### PR TITLE
feat: added ohdab logo to JSON config file

### DIFF
--- a/ols4/ohdab.json
+++ b/ols4/ohdab.json
@@ -7,6 +7,7 @@
       "uri": "https://database.factgrid.de/ohdab",
       "description":"This version of the historical German-language nomenclature for offices and professions (OhdAB) was automatically generated via a script from FactGrid.",
       "homepage":"https://database.factgrid.de",
+      "depicted_by": "https://www.geschichte.uni-halle.de/im/1750321064_320_0.png",
       "hierarchical_property": [
           "https://w3id.org/omw/broader"
       ],


### PR DESCRIPTION
I added the [OhdAB logo](https://www.geschichte.uni-halle.de/im/1750321064_320_0.png) into the JSON config file, similar to how it was done in the [Uberon config file](https://github.com/EBISPOT/ols4/blob/b61fe004db1572a7488f8bb62164e8e1155dc154/dataload/configs/uberon.json#L75C7-L75C143).

Uberon config file:
<img width="1142" height="180" alt="image" src="https://github.com/user-attachments/assets/03615a24-5ea3-474f-b117-b314a0f2d07b" />

OhdAB config file:
<img width="1088" height="275" alt="image" src="https://github.com/user-attachments/assets/3387285a-0a58-4290-a2bc-69b6a9c284b9" />

Closes #9.