### PR TITLE
feat: check for missing parents

### DIFF
--- a/.github/workflows/ohdab_missing_parents_issue.yml
+++ b/.github/workflows/ohdab_missing_parents_issue.yml
@@ -1,0 +1,4 @@
+name: Create Issue for classes without real parents in OhdAB
+on:
+
+jobs:

--- a/.github/workflows/ohdab_missing_parents_issue.yml
+++ b/.github/workflows/ohdab_missing_parents_issue.yml
@@ -1,4 +1,0 @@
-name: Create Issue for classes without real parents in OhdAB
-on:
-
-jobs:

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -34,10 +34,12 @@ jobs:
       - name: Check whether issue file exists
         id: issue_file_check
         run: |
-          if [ -s "ohdab/resources/missing_parents_issue_text.txt" ]; then
+          if [ -s "ohdab/resources/missing_parents_issue_text.md" ]; then
             echo "issuefile_exists=true" >> "$GITHUB_OUTPUT"
+            echo "Issue file found. Creating GitHub issue and skipping commit."
           else
             echo "issuefile_exists=false" >> "$GITHUB_OUTPUT"
+            echo "No issue file found. Skipping issue creation and committing OhdAB.ttl."
           fi
 
       - name: Create issue for missing parents

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   run-python-file:
@@ -20,14 +21,31 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: install dependencies
+      - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: run ohdab/main.py
+      - name: Run ohdab/main.py
         working-directory: ./ohdab
         run: python main.py
 
-      - name: commit OhdAB.ttl
+      - name: Check whether issue file exists
+        id: issue_file_check
+        run: |
+          if [ -s "ohdab/resources/missing_parents_issue_text.txt" ]; then
+            echo "issuefile_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "issuefile_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger issue creation workflow
+        if: steps.issue_file_check.outputs.issuefile_exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run ohdab_missing_parents_issue.yml
+            
+
+      - name: Commit OhdAB.ttl
+        if: steps.issue_file_check.outputs.issuefile_exists == 'false'
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -3,9 +3,6 @@ on:
   schedule:
     - cron: "4 5 * * 0"
   workflow_dispatch:
-  push:
-    branches:
-      - 16-check-for-missing-parents
 
 permissions:
   contents: write
@@ -47,7 +44,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Creating issue because classes with missing parents exist. Skipping commit."
           gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
             
 

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-  actions: write
+  issues: write
 
 jobs:
   run-python-file:
@@ -37,11 +37,12 @@ jobs:
             echo "issuefile_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Trigger issue creation workflow
+      - name: Create issue for missing parents
         if: steps.issue_file_check.outputs.issuefile_exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run ohdab_missing_parents_issue.yml
+        run: |
+          gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
             
 
       - name: Commit OhdAB.ttl

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -3,6 +3,9 @@ on:
   schedule:
     - cron: "4 5 * * 0"
   workflow_dispatch:
+  push:
+    branches:
+      - 16-check-for-missing-parents
 
 permissions:
   contents: write
@@ -42,6 +45,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "Creating issue because classes with missing parents exist. Skipping commit."
           gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
             
 

--- a/ohdab/issue_text_builder.py
+++ b/ohdab/issue_text_builder.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+RESOURCES_DIR = Path(__file__).resolve().parent / "resources"
+RESOURCES_DIR.mkdir(parents=True, exist_ok=True)
+
+def write_missing_hierarchy_issue_text(classes_without_real_parent: list):
+    output_file = "iris_missing_hierarchy_issue_text.txt"
+    with open(RESOURCES_DIR / output_file, "w", encoding="utf-8") as f:
+        f.write("# Classes without real parent\n\n")
+        f.write("The OhdAB ontology contains the following classes, which do not have a parent class except themselves and therefore do not get sorted into the hierarchy:\n\n")
+
+        for uri in classes_without_real_parent:
+            f.write(f"- `{uri}`\n")
+
+        f.write("\n\n")
+        f.write("cc @1, @2")

--- a/ohdab/issue_text_builder.py
+++ b/ohdab/issue_text_builder.py
@@ -3,7 +3,7 @@ from pathlib import Path
 RESOURCES_DIR = Path(__file__).resolve().parent / "resources"
 RESOURCES_DIR.mkdir(parents=True, exist_ok=True)
 
-def write_missing_hierarchy_issue_text(classes_without_real_parent: list):
+def write_missing_parents_issue_text(classes_without_real_parent: list):
     output_file = "missing_parents_issue_text.md"
     with open(RESOURCES_DIR / output_file, "w", encoding="utf-8") as f:
         f.write("# Classes without real parent\n\n")

--- a/ohdab/issue_text_builder.py
+++ b/ohdab/issue_text_builder.py
@@ -6,11 +6,11 @@ RESOURCES_DIR.mkdir(parents=True, exist_ok=True)
 def write_missing_parents_issue_text(classes_without_real_parent: list):
     output_file = "missing_parents_issue_text.md"
     with open(RESOURCES_DIR / output_file, "w", encoding="utf-8") as f:
-        f.write("# Classes without real parent\n\n")
+        f.write("## Classes without real parent\n\n")
         f.write("The OhdAB ontology contains the following classes, which do not have a parent class except themselves and therefore do not get sorted into the hierarchy:\n\n")
 
         for uri in classes_without_real_parent:
             f.write(f"- `{uri}`\n")
 
         f.write("\n\n")
-        f.write("cc @1, @2")
+        f.write("cc @OlafSimons, @FactGrid")

--- a/ohdab/issue_text_builder.py
+++ b/ohdab/issue_text_builder.py
@@ -4,7 +4,7 @@ RESOURCES_DIR = Path(__file__).resolve().parent / "resources"
 RESOURCES_DIR.mkdir(parents=True, exist_ok=True)
 
 def write_missing_hierarchy_issue_text(classes_without_real_parent: list):
-    output_file = "iris_missing_hierarchy_issue_text.txt"
+    output_file = "missing_parents_issue_text.txt"
     with open(RESOURCES_DIR / output_file, "w", encoding="utf-8") as f:
         f.write("# Classes without real parent\n\n")
         f.write("The OhdAB ontology contains the following classes, which do not have a parent class except themselves and therefore do not get sorted into the hierarchy:\n\n")

--- a/ohdab/issue_text_builder.py
+++ b/ohdab/issue_text_builder.py
@@ -4,7 +4,7 @@ RESOURCES_DIR = Path(__file__).resolve().parent / "resources"
 RESOURCES_DIR.mkdir(parents=True, exist_ok=True)
 
 def write_missing_hierarchy_issue_text(classes_without_real_parent: list):
-    output_file = "missing_parents_issue_text.txt"
+    output_file = "missing_parents_issue_text.md"
     with open(RESOURCES_DIR / output_file, "w", encoding="utf-8") as f:
         f.write("# Classes without real parent\n\n")
         f.write("The OhdAB ontology contains the following classes, which do not have a parent class except themselves and therefore do not get sorted into the hierarchy:\n\n")

--- a/ohdab/main.py
+++ b/ohdab/main.py
@@ -1,7 +1,7 @@
 from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib import Graph, Namespace, Literal, URIRef
 from rdflib.namespace import OWL, RDF, RDFS, DCTERMS, XSD, SKOS
-from issue_text_builder import write_missing_hierarchy_issue_text
+from issue_text_builder import write_missing_parents_issue_text
 
 import json
 import os
@@ -273,7 +273,7 @@ def create_as_classes(g, merged_results):
 
     if classes_without_real_parent:
         print("There are classes which do not have a parent class (except their own)")
-        write_missing_hierarchy_issue_text(classes_without_real_parent)
+        write_missing_parents_issue_text(classes_without_real_parent)
 
 def merge_results(results_de, results_en):
     merged = {}

--- a/ohdab/main.py
+++ b/ohdab/main.py
@@ -1,6 +1,7 @@
 from SPARQLWrapper import SPARQLWrapper, JSON
 from rdflib import Graph, Namespace, Literal, URIRef
 from rdflib.namespace import OWL, RDF, RDFS, DCTERMS, XSD, SKOS
+from issue_text_builder import write_missing_hierarchy_issue_text
 
 import json
 import os
@@ -196,6 +197,8 @@ def create_as_terms(g, results):
 
 
 def create_as_classes(g, merged_results):
+    classes_without_real_parent = []
+
     for entry in merged_results.values():
 
         # Use DE URI (same as EN)
@@ -240,6 +243,7 @@ def create_as_classes(g, merged_results):
         levels = ["OhdAB_01", "OhdAB_02", "OhdAB_03", "OhdAB_04", "OhdAB_05", "OhdAB_AB"]
 
         prev_uri = class_uri
+        has_real_parent = False
 
         for lvl in levels:
             key_de = f"{lvl}_de"
@@ -248,7 +252,9 @@ def create_as_classes(g, merged_results):
 
             if key_de in entry:
                 lvl_uri = URIRef(entry[key_de])
-
+                # this only gets triggered if the class has a parent different from itself
+                if not (prev_uri == lvl_uri):
+                    has_real_parent = True
                 g.add((prev_uri, RDFS.subClassOf, lvl_uri))
                 g.add((lvl_uri, RDF.type, RDFS.Class))
 
@@ -262,6 +268,12 @@ def create_as_classes(g, merged_results):
 
                 prev_uri = lvl_uri
 
+        if not has_real_parent:
+            classes_without_real_parent.append(class_uri)
+
+    if classes_without_real_parent:
+        print("There are classes which do not have a parent class (except their own)")
+        write_missing_hierarchy_issue_text(classes_without_real_parent)
 
 def merge_results(results_de, results_en):
     merged = {}
@@ -304,3 +316,4 @@ if __name__ == "__main__":
     add_ontology_metadata(G)
     G.serialize("OhdAB.ttl", format="turtle")
     print("RDF exported to OhdAB.ttl")
+


### PR DESCRIPTION
## Summary

The `ohdab/main.py` script now checks during graph construction whether there are classes that have no parents other than themselves. These classes are not sorted correctly into the hierarchy, so `OhdAB.ttl` should not be updated if the newest version contains such classes.

The `update_ohdab` workflow now only commits new changes to `OhdAB.ttl` if no such classes are found. If such classes exist, the workflow creates a new issue listing all IRIs of the classes without real parents and mentions _OlafSimons_ and _FactGrid_. The issue text is generated by `issue_text_builder.py`.

I tested the workflow successfully. [Here](https://github.com/ts4nfdi/Wikibase-ts-convert/actions/runs/26279254179) is the test workflow run and #19 is the by the workflow run created issue.


Closes #16 