### PR TITLE
feat: avoid duplication of tickets

### DIFF
--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -39,13 +39,44 @@ jobs:
             echo "No issue file found. Skipping issue creation and committing OhdAB.ttl."
           fi
 
-      - name: Create issue for missing parents
-        if: steps.issue_file_check.outputs.issuefile_exists == 'true'
+      - name: Check if issue exists
+        id: issue_check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
-            
+          ISSUE_NUMBER=$(gh issue list --state open \
+            --json number,title \
+            --jq '[.[] | select(.title == "OhdAB classes without real parents")] | 
+                  if length == 1 then .[0].number
+                  elif length == 0 then empty
+                  else error("More than one matching issue found")
+                  end')
+          
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "issue_exists=true" >> "$GITHUB_OUTPUT"
+            echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
+            echo "Issue already exists: #$ISSUE_NUMBER"
+          else
+            echo "issue_exists=false" >> "$GITHUB_OUTPUT"
+            echo "No matching issue found"
+          fi
+          
+
+      - name: Create issue for missing parents
+        if: steps.issue_file_check.outputs.issuefile_exists == 'true' && steps.issue_check.outputs.issue_exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
+
+      - name: Edit issue for missing parents
+        if: steps.issue_file_check.outputs.issuefile_exists == 'true' && steps.issue_check.outputs.issue_exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue edit ${{ steps.issue_check.outputs.issue_number }} --body-file "ohdab/resources/missing_parents_issue_text.md"
+
+      - name: Delete issue for missing parents
+        if: steps.issue_file_check.outputs.issuefile_exists == 'false' && steps.issue_check.outputs.issue_exists == 'false'
+        run: gh issue close ${{ steps.issue_check.outputs.issue_number }} --comment "Newest version of OhdAB contains no IRI's without real parents"
 
       - name: Commit OhdAB.ttl
         if: steps.issue_file_check.outputs.issuefile_exists == 'false'

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -2,6 +2,9 @@ name: Update OhdAB ontology
 on:
   schedule:
     - cron: "4 5 * * 0"
+  push:
+    branches:
+      - feat/avoid-duplication-of-tickets
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -36,10 +36,10 @@ jobs:
         run: |
           if [ -s "ohdab/resources/missing_parents_issue_text.md" ]; then
             echo "issuefile_exists=true" >> "$GITHUB_OUTPUT"
-            echo "Issue file found. Creating GitHub issue and skipping commit."
+            echo "Issue file found."
           else
             echo "issuefile_exists=false" >> "$GITHUB_OUTPUT"
-            echo "No issue file found. Skipping issue creation and committing OhdAB.ttl."
+            echo "No issue file found."
           fi
 
       - name: Check if issue exists
@@ -58,10 +58,10 @@ jobs:
           if [ -n "$ISSUE_NUMBER" ]; then
             echo "issue_exists=true" >> "$GITHUB_OUTPUT"
             echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-            echo "Issue already exists: #$ISSUE_NUMBER"
+            echo "Matching issue found: #$ISSUE_NUMBER."
           else
             echo "issue_exists=false" >> "$GITHUB_OUTPUT"
-            echo "No matching issue found"
+            echo "No matching issue found."
           fi
           
 
@@ -69,19 +69,25 @@ jobs:
         if: steps.issue_file_check.outputs.issuefile_exists == 'true' && steps.issue_check.outputs.issue_exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
+        run: |
+          gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
+          echo "Created new issue."
 
       - name: Edit issue
         if: steps.issue_file_check.outputs.issuefile_exists == 'true' && steps.issue_check.outputs.issue_exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh issue edit ${{ steps.issue_check.outputs.issue_number }} --body-file "ohdab/resources/missing_parents_issue_text.md"
+        run: |
+          gh issue edit ${{ steps.issue_check.outputs.issue_number }} --body-file "ohdab/resources/missing_parents_issue_text.md"
+          echo "Edited existing issue."
 
       - name: Close issue
         if: steps.issue_file_check.outputs.issuefile_exists == 'false' && steps.issue_check.outputs.issue_exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh issue close ${{ steps.issue_check.outputs.issue_number }} --comment "Newest version of OhdAB contains no IRIs without real parents"
+        run: |
+          gh issue close ${{ steps.issue_check.outputs.issue_number }} --comment "Newest version of OhdAB contains no IRIs without real parents"
+          echo "Closed issue."
 
       - name: Commit OhdAB.ttl
         if: steps.issue_file_check.outputs.issuefile_exists == 'false'
@@ -89,5 +95,10 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
           git add ./ohdab/OhdAB.ttl
-          git commit -m "Update OhdAB.ttl" || echo "No changes to commit"
+          if git commit -m "Update OhdAB.ttl"; then
+            git push
+            echo "Committed OhdAB.ttl update."
+          else
+            echo "No changes to commit."
+          fi
           git push

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -62,21 +62,23 @@ jobs:
           fi
           
 
-      - name: Create issue for missing parents
+      - name: Create issue
         if: steps.issue_file_check.outputs.issuefile_exists == 'true' && steps.issue_check.outputs.issue_exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh issue create --title "OhdAB classes without real parents" --body-file "ohdab/resources/missing_parents_issue_text.md"
 
-      - name: Edit issue for missing parents
+      - name: Edit issue
         if: steps.issue_file_check.outputs.issuefile_exists == 'true' && steps.issue_check.outputs.issue_exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh issue edit ${{ steps.issue_check.outputs.issue_number }} --body-file "ohdab/resources/missing_parents_issue_text.md"
 
-      - name: Delete issue for missing parents
-        if: steps.issue_file_check.outputs.issuefile_exists == 'false' && steps.issue_check.outputs.issue_exists == 'false'
-        run: gh issue close ${{ steps.issue_check.outputs.issue_number }} --comment "Newest version of OhdAB contains no IRI's without real parents"
+      - name: Close issue
+        if: steps.issue_file_check.outputs.issuefile_exists == 'false' && steps.issue_check.outputs.issue_exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue close ${{ steps.issue_check.outputs.issue_number }} --comment "Newest version of OhdAB contains no IRIs without real parents"
 
       - name: Commit OhdAB.ttl
         if: steps.issue_file_check.outputs.issuefile_exists == 'false'

--- a/.github/workflows/update_ohdab.yml
+++ b/.github/workflows/update_ohdab.yml
@@ -2,9 +2,6 @@ name: Update OhdAB ontology
 on:
   schedule:
     - cron: "4 5 * * 0"
-  push:
-    branches:
-      - feat/avoid-duplication-of-tickets
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

I only made changes to the workflow file. The workflow now checks whether there are `IRIs without parents (or with self-referential parent relationships)` and whether an `issue` for this already exists. Based on these two variables the following actions are taken:

- If `no issue` and `IRIs without parents` exist -> New Issue gets created
- If `issue` and `IRIs without parents` exist -> The body of the issue gets overwritten with all new found IRIs. Therefore IRIs which now don't have a problem get deleted and new IRIs without parents get added.
- If `issue` and `no IRIs without parents` exist -> The issue gets deleted
- If `no IRIs without parents` exist -> OhdAB.ttl gets committed if it has any changes

## Additional Info

- I am not sure whether _OlafSimons_ and _FactGrid_ are notified again when the issue body is edited. I assume this should not happen.
- The workflow fails if multiple issues with the exact title "OhdAB classes without real parents" exist. I think that makes sense, because in that case something is probably wrong anyway, and otherwise it would no longer be deterministic which issue should be updated.

Closes #23 